### PR TITLE
HMR: Hot Module Reloading for app development

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,6 +35,14 @@
             "scripts": []
           },
           "configurations": {
+            "hmr": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.hmr.ts"
+                }
+              ]
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -67,6 +75,9 @@
             "browserTarget": "rxjs-visualize:build"
           },
           "configurations": {
+            "hmr": {
+              "browserTarget": "rxjs-visualize:build:hmr"
+            },
             "production": {
               "browserTarget": "rxjs-visualize:build:production"
             }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@angular-devkit/build-angular": "^0.11.3",
     "@angular/cli": "^7.1.3",
     "@angular/compiler-cli": "^7.1.3",
+    "@angularclass/hmr": "^2.1.3",
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/plugin-proposal-decorators": "^7.2.2",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -78,6 +78,8 @@ export class RxVisualizationsAppComponent implements OnInit {
   navOpen = true;
 
   ngOnInit() {
-    this.fadeInState = 'in';
+    if (!module['hot']) {
+      this.fadeInState = 'in';
+    }
   }
 }

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  hmr: false,
+  hmr: true,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
   production: true,
+  hmr: false,
 };

--- a/src/hmr.ts
+++ b/src/hmr.ts
@@ -1,0 +1,18 @@
+import { NgModuleRef, ApplicationRef } from '@angular/core';
+import { createNewHosts } from '@angularclass/hmr';
+
+export const hmrBootstrap = (
+  module: any,
+  bootstrap: () => Promise<NgModuleRef<any>>,
+) => {
+  let ngModule: NgModuleRef<any>;
+  module.hot.accept();
+  bootstrap().then(mod => (ngModule = mod));
+  module.hot.dispose(() => {
+    const appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
+    const elements = appRef.components.map(c => c.location.nativeElement);
+    const makeVisible = createNewHosts(elements);
+    ngModule.destroy();
+    makeVisible();
+  });
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,22 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+import { hmrBootstrap } from './hmr';
+
 if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule);
+const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
+bootstrap();
+
+if (environment.hmr) {
+  if (module['hot']) {
+    hmrBootstrap(module, bootstrap);
+  } else {
+    console.error('HMR is not enabled for webpack-dev-server!');
+    console.error('Are you using the --hmr flag for ng serve?');
+  }
+} else {
+  bootstrap();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ if (environment.production) {
 }
 
 const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
-bootstrap();
 
 if (environment.hmr) {
   if (module['hot']) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,11 @@
   dependencies:
     tslib "^1.9.0"
 
+"@angularclass/hmr@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@angularclass/hmr/-/hmr-2.1.3.tgz#34e658ed3da37f23b0a200e2da5a89be92bb209f"
+  integrity sha1-NOZY7T2jfyOwogDi2lqJvpK7IJ8=
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"


### PR DESCRIPTION
This was largely taken from https://medium.com/@beeman/tutorial-enable-hmr-in-angular-cli-apps-1b0d13b80130 and uses the @angularclass/hmr npm package for Angular hot module reloading.

One unique change is to avoid the initial fade-in animation when using hot module reloading to reduce the visual delay for developers.