### PR TITLE
feat(visualizations): Improving shareReplay visualization

### DIFF
--- a/src/app/visualizations/operators/shareReplay.ts
+++ b/src/app/visualizations/operators/shareReplay.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 import { timer } from 'rxjs';
-import { take, shareReplay, mergeMapTo } from 'rxjs/operators';
+import { take, shareReplay, mergeMapTo, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'rx-share-replay',
@@ -12,33 +12,37 @@ import { take, shareReplay, mergeMapTo } from 'rxjs/operators';
       subscriptions. One interesting note is that this replays from subscription
       to the *subject* Observable rather than the source Observable. If we
       didn't have a visualization for the subject (which creates a
-      subscription), <code>output</code> would emit the same as
+      subscription), <code>delayedOutput</code> would emit the same as
       <code>input</code> other than the initial delay.
     </p>
     <p>
-      The replayed values are emitted all at once. The only difference from
-      <a routerLink="/share"><code>share</code></a> is that
-      <code>shareReplay</code> can replay values. <code>share</code> does not
-      replay any values. <code>shareReplay()</code> will replay
-      <em>all</em> values.
+      Notice how the logs only output twice. These are from the subscriptions
+      that happen for <code>input</code> and <code>subject</code>.
+      <code>delayedOutput</code>, since it's subscribing to our subject, does
+      not output a log.
     </p>
     <p>
-      This visualization doesn't really show off the
-      <code>share</code> capabilities and can probably be improved. See the
-      <a routerLink="/share"><code>share</code></a> visualization to see what I
-      mean.
+      The replayed values are emitted all at once. It's hard to see because the
+      marbles overlap. The only difference from
+      <a routerLink="/share"><code>share</code></a> is that
+      <code>shareReplay</code> can replay values. <code>share</code> does not
+      replay any values. <code>shareReplay</code> will replay
+      <em>all</em> values.
     </p>
     <pre prism-highlight="typescript">{{ code }}</pre>
 
     <rxjs-visualize-marble [source]="input"></rxjs-visualize-marble>
     <rxjs-visualize-marble [source]="subject"></rxjs-visualize-marble>
-    <rxjs-visualize-marble [source]="output"></rxjs-visualize-marble>
+    <rxjs-visualize-marble [source]="delayedOutput"></rxjs-visualize-marble>
   `,
 })
 export class RxShareReplayComponent {
   code = preval`module.exports = require('../codefile')(__filename)`;
-
-  input = timer(0, 1000).pipe(take(4));
+  input = timer(0, 1000).pipe(
+    take(4),
+    // tslint:disable-next-line:no-console ... open your console!
+    tap(val => val === 0 && console.log('new producer created!')),
+  );
   subject = this.input.pipe(shareReplay(2));
-  output = timer(3500).pipe(mergeMapTo(this.subject));
+  delayedOutput = timer(2000).pipe(mergeMapTo(this.subject));
 }


### PR DESCRIPTION
* Add console logs to demonstrate 'share' portion of the operator.
* Change the timing of the outputs a bit to visualize 'share' better.
* Remove comment about improvements being needed
* Do some renaming.

![sharereplay](https://user-images.githubusercontent.com/2723491/52167659-66c78580-26ec-11e9-9334-a1ceff3637a9.gif)
